### PR TITLE
Merge version 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ The following special marks are supported:
 |------|------------------------------------|
 | `<`  | Beginning of last visual selection |
 | `>`  | End of last visual selection       |
+| `[`  | Beginning of last pasted segment   |
+| `]`  | End of last pasted segment         |
 | `.`  | Last change in current buffer      |
 | `^`  | End of last insertion              |
 | `{`  | Beginning of current paragraph     |

--- a/README.md
+++ b/README.md
@@ -48,6 +48,26 @@ To switch the fringe in which mark overlays are displayed (`left-fringe` by defa
 
 Regardless of in which fringe you choose to display marks, it is recommended that you increase the width of that fringe to fully display wide characters.
 
+### Switch display margin
+
+As non-graphical Emacs sessions do not support fringe display, `evil-fringe-mark` displays marks in the margin instead in such environments.  To switch the margin in which marks are displayed (`left-margin` by default), include a variation of the following in your Emacs configuration:
+
+```
+;; Use left margin
+(setq-default left-margin-width 2)
+(setq-default evil-fringe-mark-margin 'left-margin)
+
+;; Use right margin
+(setq-default right-margin-width 2)
+(setq-default evil-fringe-mark-margin 'right-margin)
+```
+
+Regardless of in which margin you choose to display marks, you must set a `*-margin-width` variable to a value greater than `0` for marks to appear.  Furthermore, setting one of these variables to a value greater than `1` will allow for multiple marks to be displayed per line if `evil-fringe-mark-always-overwrite` is set to `nil`.
+
+### Display only the most recently-placed mark on each line
+
+To display only the most recently-placed mark on each line, set `evil-fringe-mark-always-overwrite` to a non-`nil` value (`t` by default).  It is recommended that this variable not be set to `nil` in graphical Emacs sessions, as doing so could result in unintuitive behaviour.  In non-graphical sessions, setting it to `nil` will allow multiple marks to be displayed in the margin for each line, provided that a `*-margin-width` variable is set to a value greater than `1`; multiple mark display is not supported in the graphical fringe.
+
 ### Display special marks
 
 By default, `evil-fringe-mark` does not display automatically-placed special marks in the fringe.  To display these marks, set `evil-fringe-mark-show-special` to a non-`nil` value in your Emacs configuration:

--- a/evil-fringe-mark-overlays.el
+++ b/evil-fringe-mark-overlays.el
@@ -5,7 +5,7 @@
 
 ;; Author: Andrew Smith <andy.bill.smith@gmail.com>
 ;; URL: https://github.com/Andrew-William-Smith/evil-fringe-mark
-;; Version: 1.1.1
+;; Version: 1.2.0
 ;; Package-Requires: ((emacs "24.3") (evil "1.0.0") (fringe-helper "0.1.1") (goto-chg "1.6"))
 
 ;; This file is part of evil-fringe-mark.

--- a/evil-fringe-mark-overlays.el
+++ b/evil-fringe-mark-overlays.el
@@ -1206,6 +1206,66 @@
   "XXXX...."
   "XXX.....")
 
+(fringe-helper-define 'evil-fringe-mark-symbol-lsquare '(center)
+  "XXXXXXXX"
+  "XXXXXXXX"
+  "XX......"
+  "XX......"
+  "XX......"
+  "XX......"
+  "XX......"
+  "XX......"
+  "XX......"
+  "XX......"
+  "XX......"
+  "XX......"
+  "XX......"
+  "XX......"
+  "XX......"
+  "XX......"
+  "XXXXXXXX"
+  "XXXXXXXX")
+
+(fringe-helper-define 'evil-fringe-mark-symbol-rsquare '(center)
+  "XXXXXXXX"
+  "XXXXXXXX"
+  "......XX"
+  "......XX"
+  "......XX"
+  "......XX"
+  "......XX"
+  "......XX"
+  "......XX"
+  "......XX"
+  "......XX"
+  "......XX"
+  "......XX"
+  "......XX"
+  "......XX"
+  "......XX"
+  "XXXXXXXX"
+  "XXXXXXXX")
+
+(fringe-helper-define 'evil-fringe-mark-symbol-lrsquare '(center)
+  "XXXXXXXX"
+  "XXXXXXXX"
+  "XX......"
+  "XX......"
+  "XX..XXXX"
+  "XX..XXXX"
+  "XX....XX"
+  "XX....XX"
+  "XX....XX"
+  "XX....XX"
+  "XX....XX"
+  "XX....XX"
+  "XXXX..XX"
+  "XXXX..XX"
+  "......XX"
+  "......XX"
+  "XXXXXXXX"
+  "XXXXXXXX")
+
 
 (defvar evil-fringe-mark-bitmaps '(( 46 . evil-fringe-mark-symbol-period)
                                    ( 60 . evil-fringe-mark-symbol-lt)
@@ -1236,6 +1296,8 @@
                                    ( 88 . evil-fringe-mark-upper-x)
                                    ( 89 . evil-fringe-mark-upper-y)
                                    ( 90 . evil-fringe-mark-upper-z)
+                                   ( 91 . evil-fringe-mark-symbol-lsquare)
+                                   ( 93 . evil-fringe-mark-symbol-rsquare)
                                    ( 94 . evil-fringe-mark-symbol-caron)
                                    ( 97 . evil-fringe-mark-lower-a)
                                    ( 98 . evil-fringe-mark-lower-b)
@@ -1265,7 +1327,8 @@
                                    (122 . evil-fringe-mark-lower-z)
                                    (123 . evil-fringe-mark-symbol-lcurly)
                                    (125 . evil-fringe-mark-symbol-rcurly)
-                                   (128 . evil-fringe-mark-symbol-gtlt))
+                                   (128 . evil-fringe-mark-symbol-gtlt)
+                                   (129 . evil-fringe-mark-symbol-lrsquare))
   "Alist of fringe bitmaps to display for characters.")
 
 (provide 'evil-fringe-mark-overlays)

--- a/evil-fringe-mark.el
+++ b/evil-fringe-mark.el
@@ -131,7 +131,7 @@ it was placed first."
                  (cl-return))))
     mark-on-line))
 
-(defun evil-fringe-mark-put (char char-list marker)
+(defun evil-fringe-mark-put (char char-list marker &optional no-recurse)
   "Place an indicator for mark CHAR, of type CHAR-LIST, in the fringe at location
 MARKER."
   (unless (or (member char evil-fringe-mark-ignore-chars)
@@ -141,7 +141,7 @@ MARKER."
             (overwritten-char (plist-get evil-fringe-mark-overwritten-list char))
             (overwrite-overlay (plist-get (symbol-value (evil-fringe-mark-char-list char)) char))
             (overwrite-marker (make-marker)))
-        (when old-mark
+        (when (and old-mark (not no-recurse))
           (evil-fringe-mark-delete (car old-mark))
           (setq evil-fringe-mark-overwritten-list
                 (plist-put evil-fringe-mark-overwritten-list char (car old-mark))))
@@ -149,7 +149,7 @@ MARKER."
           (set-marker overwrite-marker (overlay-start overwrite-overlay))
           (evil-fringe-mark-put overwritten-char
                                 (evil-fringe-mark-char-list overwritten-char)
-                                overwrite-marker))
+                                overwrite-marker t))
         (cl-loop for (newer overwritten) on evil-fringe-mark-overwritten-list by 'cddr do
                  (when (eq overwritten char)
                    (setq evil-fringe-mark-overwritten-list

--- a/evil-fringe-mark.el
+++ b/evil-fringe-mark.el
@@ -58,7 +58,8 @@
 
 (make-variable-buffer-local
  (defvar evil-fringe-mark-overwritten-list '()
-   "Plist of fringe characters that have been overwritten."))
+   "List of lists of fringe characters that have been overwritten.  Each list
+behaves as a linked list, with the most recently-placed mark at the head (car)."))
 
 (defvar evil-fringe-mark-special-chars '(?< ?> 128 ?. ?^ ?{ ?} ?\[ ?\] 129)
   "List of characters to consider special marks.")
@@ -80,12 +81,12 @@ it was placed first."
   :type 'boolean)
 
 (defcustom evil-fringe-mark-side 'left-fringe
-  "Fringe in which to place mark overlays."
+  "Fringe in which to place mark overlays for graphical Emacs sessions."
   :type '(choice (const :tag "Left fringe" left-fringe)
                  (const :tag "Right fringe" right-fringe)))
 
 (defcustom evil-fringe-mark-margin 'left-margin
-  "Fringe in which to place mark overlays."
+  "Margin in which to place mark overlays for non-graphical Emacs sessions."
   :type '(choice (const :tag "Left margin" left-margin)
                  (const :tag "Right margin" right-margin)))
 
@@ -161,9 +162,11 @@ MARKER."
         ; Prepend new mark to line overwrite list
         (when (and old-mark (not no-recurse))
           (evil-fringe-mark-delete (car old-mark))
-          (if old-stack
-              (push char (car (member old-stack evil-fringe-mark-overwritten-list)))
-            (push `(,char ,(car old-mark)) evil-fringe-mark-overwritten-list)))
+          ; Prevent overwriting same character
+          (unless (eq (car old-mark) char)
+            (if old-stack
+                (push char (car (member old-stack evil-fringe-mark-overwritten-list)))
+              (push `(,char ,(car old-mark)) evil-fringe-mark-overwritten-list))))
         ; Draw new head of line overwrite list
         (when this-stack
           (when overwrite-overlay


### PR DESCRIPTION
List of changes for version 1.2.0:

- Added support for displaying (multiple) marks in non-graphical Emacs sessions
- Fixed bugs related to overwriting marks and placing multiple marks on the same line
- Improved overall stability

This version further aims to solve Issues #1 and #3.